### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Label-Sync.yml
+++ b/.github/workflows/Label-Sync.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   labeler:
     name: Labeler
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/N-D-B-Project/N-D-B/security/code-scanning/14](https://github.com/N-D-B-Project/N-D-B/security/code-scanning/14)

To fix the problem, add a `permissions` block to the job definition at `.github/workflows/Label-Sync.yml`, limiting GITHUB_TOKEN to only the permissions required by the workflow. For the label sync action, you typically need to read repository contents and "write" to repository issues to manage labels. The minimal set is:
```yaml
permissions:
  contents: read
  issues: write
```
You should place this block under `jobs.labeler` (i.e., starting at line 13, within the labeler job definition), just above or below `runs-on`. No changes are required to the steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
