### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Greetings.yml
+++ b/.github/workflows/Greetings.yml
@@ -1,4 +1,8 @@
 name: Greetings
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 on: [pull_request, issues]
 


### PR DESCRIPTION
Potential fix for [https://github.com/N-D-B-Project/N-D-B/security/code-scanning/13](https://github.com/N-D-B-Project/N-D-B/security/code-scanning/13)

To address the problem, add a `permissions` key to restrict the `GITHUB_TOKEN` privileges to only those necessary for the job. Since the job uses `actions/first-interaction@v3`, which only needs to write comments on issues and pull requests, we should set `contents: read`, `issues: write`, and `pull-requests: write`. The fix should add this `permissions:` block either at the top level (workflow-level, right after `name` and before `on: ...`) or at the job level (under `greeting:`). For greatest clarity and future-proofing, it's common to set it at the workflow-level so all jobs inherit it. Insert the block after `name: Greetings`.

No new imports, methods, or definitions are needed—just the addition of this YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
