### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/N-D-B-Project/N-D-B/security/code-scanning/11](https://github.com/N-D-B-Project/N-D-B/security/code-scanning/11)

To fix the issue, we should add a `permissions:` block specifying the minimum set of required permissions for the workflow. Since the workflow only checks out the code, sets up Node.js, manages submodules, and installs dependencies, it does not need write permissions for repository contents or other scopes. The safest minimal set to begin with is `permissions: contents: read`. You should add this block at either the workflow root (applies to all jobs by default) or at the job level (applies only to the build job). Given that there is only one job, adding it at the root is cleaner.

Edit `.github/workflows/NodeJS.yml` and add:

```yaml
permissions:
  contents: read
```
after the `name: Node.js CI` line (line 4), so that the lowest privileged permissions are applied to the entire workflow.

No extra imports or external tools are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
